### PR TITLE
Update query

### DIFF
--- a/download_host_sqlfile.py
+++ b/download_host_sqlfile.py
@@ -116,7 +116,7 @@ def construct_sdss_query(outname, ra, dec, radius=1.0):
 
     query_template = dedent("""
     SELECT  p.objId  as objID,
-    p.ra, p.dec, p.type as phot_sg, p.flags, p.specObjID, 
+    p.ra, p.dec, p.type, dbo.fPhotoTypeN(p.type) as phot_sg, p.flags, p.specObjID, 
     p.modelMag_u as u, p.modelMag_g as g, p.modelMag_r as r,p.modelMag_i as i,p.modelMag_z as z,
     p.modelMagErr_u as u_err, p.modelMagErr_g as g_err, p.modelMagErr_r as r_err,p.modelMagErr_i as i_err,p.modelMagErr_z as z_err,
     p.extinction_u as Au, p.extinction_g as Ag, p.extinction_r as Ar, p.extinction_i as Ai, p.extinction_z as Az,

--- a/download_host_sqlfile.py
+++ b/download_host_sqlfile.py
@@ -119,6 +119,7 @@ def construct_sdss_query(outname, ra, dec, radius=1.0):
     p.ra, p.dec, p.type, dbo.fPhotoTypeN(p.type) as phot_sg, p.flags, p.specObjID, 
     p.modelMag_u as u, p.modelMag_g as g, p.modelMag_r as r,p.modelMag_i as i,p.modelMag_z as z,
     p.modelMagErr_u as u_err, p.modelMagErr_g as g_err, p.modelMagErr_r as r_err,p.modelMagErr_i as i_err,p.modelMagErr_z as z_err,
+    p.psfMag_u as psf_u, p.psfMag_g as psf_g, p.psfMag_r as psf_r, p.psfMag_i as psf_i, p.psfMag_z as psf_z,
     p.extinction_u as Au, p.extinction_g as Ag, p.extinction_r as Ar, p.extinction_i as Ai, p.extinction_z as Az,
     p.fibermag_r, p.fiber2mag_r,
     p.expRad_r, p.expMag_r + 2.5*log10(2*PI()*p.expRad_r*p.expRad_r + 1e-20) as sb_exp_r,


### PR DESCRIPTION
This makes two changes to the base catalog generation script:
- changes "phot_sg" to be _text_, either "GALAXY" or "STAR", using the `dbo.fPhotoTypeN` function that's in the SDSS SQL database.  I'm not sure how phot_sg got changed from this back to `type`, but I think (based on some of my scripts that look for the string) the string version was the original intention.  It then also adds `type`, which contains the traditional 3/6 value.
- adds PSF mags.  These are useful for some of the targeting, because picking of guide stars, flux stars, etc., is better done with PSF mags.  Usually for stars psfmag and modelmag are very close (or the same), but it seems a bit safer to ask for PSF mags when we know what we want are magnitudes for actual stars.  And some of my scripts have assume that (I might have added it to my SQL queries after sending it to you, @marlageha), so it's easier to have them in the catalog then having to hack them into the catalog
